### PR TITLE
Add Selenium UI testing workflow

### DIFF
--- a/.github/workflows/ui-testing.yml
+++ b/.github/workflows/ui-testing.yml
@@ -1,0 +1,41 @@
+name: Selenium UI Tests
+
+on:
+  pull_request:
+    branches:
+     - main
+  workflow_dispatch:
+
+jobs:
+  selenium-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+        repository: omriza5/wekan-selenium
+        token: ${{ secrets.UI_TESTING_GITHUB_TOKEN }}
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Install Chrome and ChromeDriver
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y google-chrome-stable
+
+    - name: Run Selenium tests
+      env:
+        HEADLESS: true
+        WEKAN_URL: http://${{ secrets.WEKAN_URL }}:80
+      run: |
+        pytest tests/ -v


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate Selenium-based UI testing for pull requests targeting the `main` branch. The workflow sets up the testing environment, installs dependencies, and runs the Selenium test suite in a headless Chrome browser.

**CI/CD Automation:**

* Added a new workflow file `.github/workflows/ui-testing.yml` that triggers Selenium UI tests on pull requests to the `main` branch and on manual dispatch.
* Configured the workflow to check out the code, set up Python 3.11, install dependencies, install Chrome and ChromeDriver, and execute the Selenium test suite using `pytest`.